### PR TITLE
Tap to pay

### DIFF
--- a/src/ios/CDVSumUp.m
+++ b/src/ios/CDVSumUp.m
@@ -194,4 +194,56 @@
     }
 }
 
+-(void) checkTapToPayAvailability:(CDVInvokedUrlCommand *)command {
+  [SMPSumUpSDK checkTapToPayAvailability:^(BOOL isAvailable, BOOL isActivated, NSError * _Nullable error) {
+    CDVPluginResult* pluginResult = nil;
+
+    if (error == nil) {
+      NSDictionary *dict = @{
+                             @"isAvailable" : @(isAvailable),
+                             @"isActivated" : @(isActivated)
+                             };
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dict];
+    } else {
+      NSInteger errorCode = [error code];
+      NSDictionary *dict = @{
+                             @"code" : @(errorCode),
+                             @"message" : [error localizedDescription] ?: @"Error checking Tap to Pay availability"
+                             };
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+  }];
+}
+
+-(void) presentTapToPayActivation:(CDVInvokedUrlCommand *)command {
+  [SMPSumUpSDK presentTapToPayActivationFromViewController:self.viewController
+                                                   animated:YES
+                                            completionBlock:^(BOOL success, NSError * _Nullable error) {
+    CDVPluginResult* pluginResult = nil;
+
+    if (success) {
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    } else {
+      NSInteger errorCode = error ? [error code] : 0;
+      NSDictionary *dict = @{
+                             @"code" : @(errorCode),
+                             @"message" : [error localizedDescription] ?: @"Tap to Pay activation failed"
+                             };
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+  }];
+}
+
+-(void) testSDKIntegration:(CDVInvokedUrlCommand *)command {
+  [SMPSumUpSDK testSDKIntegration];
+
+  CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+
 @end

--- a/src/ios/CDVSumUp.m
+++ b/src/ios/CDVSumUp.m
@@ -147,7 +147,7 @@
         if (error == nil && isAvailable) {
             [self showPaymentMethodSelectionForTotal:total currency:currency title:title isActivated:isActivated command:command];
         } else {
-            [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionCardReader command:command];
+            [self processPaymentWithTotal:total currency:currency title:title paymentMethod:SMPPaymentMethodCardReader command:command];
         }
     }];
 }
@@ -160,20 +160,20 @@
     UIAlertAction *cardReaderAction = [UIAlertAction actionWithTitle:@"Card Reader"
                                                                style:UIAlertActionStyleDefault
                                                              handler:^(UIAlertAction * _Nonnull action) {
-        [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionCardReader command:command];
+        [self processPaymentWithTotal:total currency:currency title:title paymentMethod:SMPPaymentMethodCardReader command:command];
     }];
 
     UIAlertAction *tapToPayAction = [UIAlertAction actionWithTitle:@"Tap to Pay"
                                                              style:UIAlertActionStyleDefault
                                                            handler:^(UIAlertAction * _Nonnull action) {
         if (isActivated) {
-            [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionTapToPay command:command];
+            [self processPaymentWithTotal:total currency:currency title:title paymentMethod:SMPPaymentMethodTapToPay command:command];
         } else {
             [SMPSumUpSDK presentTapToPayActivationFromViewController:self.viewController
                                                              animated:YES
                                                       completionBlock:^(BOOL success, NSError * _Nullable activationError) {
                 if (success) {
-                    [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionTapToPay command:command];
+                    [self processPaymentWithTotal:total currency:currency title:title paymentMethod:SMPPaymentMethodTapToPay command:command];
                 } else {
                     NSDictionary *dict = @{
                                            @"code" : @0,
@@ -209,13 +209,13 @@
     [self.viewController presentViewController:alert animated:YES completion:nil];
 }
 
--(void) processPaymentWithTotal:(NSDecimal)total currency:(NSString*)currency title:(NSString*)title paymentOption:(SMPPaymentOptions)paymentOption command:(CDVInvokedUrlCommand*)command {
+-(void) processPaymentWithTotal:(NSDecimal)total currency:(NSString*)currency title:(NSString*)title paymentMethod:(SMPPaymentMethod)paymentMethod command:(CDVInvokedUrlCommand*)command {
     CDVPluginResult* pluginResult = nil;
     SMPCheckoutRequest *request = [SMPCheckoutRequest requestWithTotal:[NSDecimalNumber decimalNumberWithDecimal:total] title:title
         currencyCode:currency];
 
     [request setSkipScreenOptions:SMPSkipScreenOptionSuccess];
-    [request setPaymentOptions:paymentOption];
+    [request setPaymentMethod:paymentMethod];
 
     [SMPSumUpSDK checkoutWithRequest:request fromViewController:self.viewController completion:^(SMPCheckoutResult *result, NSError *error) {
         CDVPluginResult* pluginResult = nil;

--- a/src/ios/CDVSumUp.m
+++ b/src/ios/CDVSumUp.m
@@ -143,11 +143,79 @@
     NSString* currency = [command.arguments objectAtIndex:1];
     NSString* title = [command.arguments objectAtIndex:2];
 
+    [SMPSumUpSDK checkTapToPayAvailability:^(BOOL isAvailable, BOOL isActivated, NSError * _Nullable error) {
+        if (error == nil && isAvailable) {
+            [self showPaymentMethodSelectionForTotal:total currency:currency title:title isActivated:isActivated command:command];
+        } else {
+            [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionCardReader command:command];
+        }
+    }];
+}
+
+-(void) showPaymentMethodSelectionForTotal:(NSDecimal)total currency:(NSString*)currency title:(NSString*)title isActivated:(BOOL)isActivated command:(CDVInvokedUrlCommand*)command {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Select Payment Method"
+                                                                   message:@"Choose how to process this payment"
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+
+    UIAlertAction *cardReaderAction = [UIAlertAction actionWithTitle:@"Card Reader"
+                                                               style:UIAlertActionStyleDefault
+                                                             handler:^(UIAlertAction * _Nonnull action) {
+        [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionCardReader command:command];
+    }];
+
+    UIAlertAction *tapToPayAction = [UIAlertAction actionWithTitle:@"Tap to Pay"
+                                                             style:UIAlertActionStyleDefault
+                                                           handler:^(UIAlertAction * _Nonnull action) {
+        if (isActivated) {
+            [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionTapToPay command:command];
+        } else {
+            [SMPSumUpSDK presentTapToPayActivationFromViewController:self.viewController
+                                                             animated:YES
+                                                      completionBlock:^(BOOL success, NSError * _Nullable activationError) {
+                if (success) {
+                    [self processPaymentWithTotal:total currency:currency title:title paymentOption:SMPPaymentOptionTapToPay command:command];
+                } else {
+                    NSDictionary *dict = @{
+                                           @"code" : @0,
+                                           @"message" : @"Tap to Pay activation cancelled"
+                                           };
+                    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
+                    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+                }
+            }];
+        }
+    }];
+
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction * _Nonnull action) {
+        NSDictionary *dict = @{
+                               @"code" : @0,
+                               @"message" : @"Payment cancelled"
+                               };
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dict];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+
+    [alert addAction:cardReaderAction];
+    [alert addAction:tapToPayAction];
+    [alert addAction:cancelAction];
+
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        alert.popoverPresentationController.sourceView = self.viewController.view;
+        alert.popoverPresentationController.sourceRect = CGRectMake(self.viewController.view.bounds.size.width / 2.0, self.viewController.view.bounds.size.height / 2.0, 1.0, 1.0);
+    }
+
+    [self.viewController presentViewController:alert animated:YES completion:nil];
+}
+
+-(void) processPaymentWithTotal:(NSDecimal)total currency:(NSString*)currency title:(NSString*)title paymentOption:(SMPPaymentOptions)paymentOption command:(CDVInvokedUrlCommand*)command {
     CDVPluginResult* pluginResult = nil;
     SMPCheckoutRequest *request = [SMPCheckoutRequest requestWithTotal:[NSDecimalNumber decimalNumberWithDecimal:total] title:title
         currencyCode:currency];
 
     [request setSkipScreenOptions:SMPSkipScreenOptionSuccess];
+    [request setPaymentOptions:paymentOption];
 
     [SMPSumUpSDK checkoutWithRequest:request fromViewController:self.viewController completion:^(SMPCheckoutResult *result, NSError *error) {
         CDVPluginResult* pluginResult = nil;
@@ -158,16 +226,16 @@
 //          }
           NSDictionary *card = result.additionalInfo[@"card"];
           NSMutableDictionary *dict = [NSMutableDictionary new];
-  
+
           NSArray *keysToCheck = @[@"transaction_code", @"merchant_code", @"amount", @"tip_amount", @"vat_amount",
                             @"currency", @"status", @"payment_type", @"entry_mode"];
-  
+
           for (NSString *key in keysToCheck) {
               if (result.additionalInfo[key]) {
                   dict[key] = result.additionalInfo[key];
               }
           }
-  
+
           if (card[@"type"]) {
               dict[@"card_type"] = card[@"type"];
           }
@@ -244,6 +312,5 @@
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
-
 
 @end

--- a/www/sumup.js
+++ b/www/sumup.js
@@ -31,5 +31,14 @@ module.exports = {
     },
     isloggedin: function() {
         return new Promise((resolve, reject) => cordova.exec(resolve, reject, 'SumUp', 'isLoggedIn', []));
+    },
+    checkTapToPayAvailability: function() {
+        return new Promise((resolve, reject) => cordova.exec(resolve, reject, 'SumUp', 'checkTapToPayAvailability', []));
+    },
+    presentTapToPayActivation: function() {
+        return new Promise((resolve, reject) => cordova.exec(resolve, reject, 'SumUp', 'presentTapToPayActivation', []));
+    },
+    testSDKIntegration: function() {
+        return new Promise((resolve, reject) => cordova.exec(resolve, reject, 'SumUp', 'testSDKIntegration', []));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Check Tap-to-Pay availability and activation status on device.
  * Initiate Tap-to-Pay activation flow from the app.
  * New payment-method selection UI during checkout (Tap-to-Pay, Card Reader, Cancel) with automatic fallback to Card Reader and retry after activation.
  * Run an SDK integration validation test (quick confirmation).
  * New JavaScript APIs to check availability, present activation, and run the test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->